### PR TITLE
restructuring for json data in POST api call

### DIFF
--- a/contrio-website/src/components/Form.js
+++ b/contrio-website/src/components/Form.js
@@ -11,7 +11,10 @@ const Form = ({ type }) => {
     const handleInputSubmit = (event) => {
         event.preventDefault();
         alert('creating contract for ' + freelancerName + " and " + clientName + " of the amount of: " + paymentAmount);
-        axios.post(`api/contracts/create/${event.target[0].value}/${event.target[2].value}`).then((response) => {
+        console.log("submitting");
+        axios.post(`api/contracts/create`, {'f_name': freelancerName, 'c_name': clientName, 'pay_amount': paymentAmount}).then((response) => {
+            console.log("submitted post request and got a response");
+            console.log(response.status);
             if (response.status === 200) {
                 console.log(response.data);
             }

--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request
+from flask import Flask, request, make_response, jsonify
 from flask_cors import CORS
 from classes.Contract import Contract
 from classes.State import State
@@ -24,28 +24,43 @@ def retrieve_active_contracts(contract_id):
         response = table.query(
         KeyConditionExpression=boto3.dynamodb.conditions.Key('id').eq(contract_id)
         )
+        print(response)
         return response
+        # response = table.get_item(
+        #     Key={
+        #         'username': 'janedoe',
+        #         'last_name': 'Doe'
+        #     }
+        # )
+        # item = response['Item']
+        # print(item)
     except Exception as e:
         print(e)
         return "Error"
 
-@app.route(BASE_ROUTE + "/create/<freelancer_id>/<contract_val>", methods=["GET","POST"])
-def create_contract(freelancer_id, contract_val):
+@app.route(BASE_ROUTE + "/create", methods=["POST"])
+def create_contract():
+    print(request.is_json)
+    if request.is_json:
+        print(request.json)
     try:
-        contract = Contract(freelancer_id, contract_val)
-        response = table.put_item(Item={
-            'id' : str(contract.get_id()),
-            'client_id': str(contract.get_client_id()),
-            'freelancer_id': str(contract.get_freelancer_id()),
-            'contract_val': contract.get_contract_val(),
-            'contract_state': str(contract.get_state())
-        })
-        # for dev purposes, can delete this line
+        contract = Contract(request.json)
+
+        # DB response is a dict object and we can create our api response based on it
+        db_response = table.put_item(Item=contract.get_json())
+        if db_response['ResponseMetadata']['HTTPStatusCode'] == 200:
+            http_response = make_response(jsonify(contract.get_json()), 200)
+        else:
+            http_response = make_response(jsonify({}), db_response['ResponseMetadata']['HTTPStatusCode'])
+
+        # # for dev purposes, can delete this line
+        # response = make_response(db_response)
         print(contract.get_id()) 
-        return response
+        return http_response
     except Exception as e:
         print(e)
         return "Error"
+        # here we should actually return an appropriate status code
 
 @app.route(BASE_ROUTE + "/approve/<client_id>/<contract_id>", methods=["GET","PUT"])
 def approve_contract(client_id, contract_id):

--- a/server/classes/Contract.py
+++ b/server/classes/Contract.py
@@ -2,12 +2,19 @@ import uuid
 from classes.State import State
 
 class Contract:
-    def __init__(self, fid, contract_val):
+    def __init__(self, contract_json):
         self.id = uuid.uuid4()
-        self.client_id = None
-        self.freelancer_id = fid
-        self.contract_val = contract_val
+        self.client_id = contract_json['c_name']
+        self.freelancer_id = contract_json['f_name']
+        self.contract_val = contract_json['pay_amount']
         self.state = State.CREATED
+
+    def get_json(self):
+        return {'id' : str(self.id),
+                'client_id': str(self.client_id),
+                'freelancer_id': str(self.freelancer_id),
+                'contract_val': str(self.contract_val),
+                'contract_state': str(self.state)}
 
     def get_id(self):
         return self.id


### PR DESCRIPTION
The only changes here are with respect to the api calls. I set up the post request on both the backend and frontend to handle json data. Obviously with a new structure for how users fill out the contract, the structure of the json will change, but this code still provides a format for how to send/recieve a json request.

(merging these branches means we can delete the json-api branch which is no longer being used)